### PR TITLE
ps2: Enable caching in knitr

### DIFF
--- a/ps2/writeup.Rnw
+++ b/ps2/writeup.Rnw
@@ -3,6 +3,10 @@
 \title{Problem Set 2}
 \author{Kaylee, Carrie, Kritphong, Filipe and Klint \\ EDUC 252L}
 
+<<echo=FALSE>>=
+knitr::opts_chunk$set(cache=TRUE)
+@
+
 \begin{document}
 \maketitle
 \section{Breaking the Classical Test Theory Model}


### PR DESCRIPTION
This makes knitr skip running R code when the document needs to be
recompiled due to changes in unrelated areas, significantly reducing
compile time in many cases.