### PR TITLE
Add patterns to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@
 .RData
 .Ruserdata
 /c*/
+ps*/cache/**
+ps*/figure/**
+ps*/*.aux
+ps*/*.log
+ps*/*.tex


### PR DESCRIPTION
Ignore aux, log, and tex files in the ps directories. The cache and
figure directories are also ignored. The output pdf file is not ignored
so that it's easy to check the output through the GitHub web interface.